### PR TITLE
Correct library reference in index.html

### DIFF
--- a/ExampleApp/webapp/index.html
+++ b/ExampleApp/webapp/index.html
@@ -7,7 +7,7 @@
     <title>ExampleApp</title>
     <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/resources/sap-ui-core.js"
         data-sap-ui-theme="sap_belize"
-        data-sap-ui-resourceroots='{"be.wl.ExampleApp": "./","be.wl.examplelibrary":"/bewlexamplelibrary"}'
+        data-sap-ui-resourceroots='{"be.wl.ExampleApp": "./","be.wl.examplelibrary":"/bewlexampleLibrary.bewlexamplelibrary"}'
         data-sap-ui-compatVersion="edge" data-sap-ui-oninit="module:sap/ui/core/ComponentSupport"
         data-sap-ui-async="true" data-sap-ui-frameOptions="trusted">
         </script>


### PR DESCRIPTION
Once I made this change in BAS, I was then able to successfully load be.wl.ExampleLibrary from be.wl.ExampleApp in CF Approuter.